### PR TITLE
Log url should be https

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -37,7 +37,7 @@
             <h3>Monitoring</h3>
             <ul>
               <li><a target="_blank" href="http://gu-radiator.appspot.com/capi.html">Radiator</a></li>
-              <li><a target="_blank" href="http://logs.capi.gutools.co.uk/">Logs</a></li>
+              <li><a target="_blank" href="https://logs.capi.gutools.co.uk/">Logs</a></li>
               <li><a target="_blank" href="http://gnmapps:7777/plrcs/capi.status">RCS status page</a></li>
             </ul>
           </div>


### PR DESCRIPTION
During a recent 24/7 incident we could not access the logs.  This was due to the wrong protocol in this radiator.  This PR fixes this issue.
