### PR TITLE
Update RCS status page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -36,7 +36,7 @@
             <ul>
               <li><a target="_blank" href="http://gu-radiator.appspot.com/capi.html">Radiator</a></li>
               <li><a target="_blank" href="https://logs.capi.gutools.co.uk/">Logs</a></li>
-              <li><a target="_blank" href="http://gnmapps:7777/plrcs/capi.status">RCS status page</a></li>
+              <li><a target="_blank" href="http://gnmapps:8888/tlib/capi.status">RCS status page</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
RCS has just migrated its app to a new port and path.
Corresponding [changes in rights feeder](https://github.com/guardian/rights-feeder/pull/14)
